### PR TITLE
Configurable port and fifo location, minor bugfix

### DIFF
--- a/eventcmd.sh
+++ b/eventcmd.sh
@@ -51,7 +51,7 @@ case "$1" in
 		query="/start/?title=${title}&artist=${artist}&coverArt=${coverArt}&album=${album}&rating=${rating}"
 		clean "$query"
 
-		echo -n "${artist},${title},${album},${coverArt},${rating}" > "$currentSong"
+		echo -n "${artist},,,${title},,,${album},,,${coverArt},,,${rating}" > "$currentSong"
 
 		stationList
 		;;

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function readCurrentSong() {
 	var currentSong = fs.readFileSync(process.env.HOME + '/.config/pianobar/currentSong').toString()
 
 	if (currentSong) {
-			var a = currentSong.split(',');
+			var a = currentSong.split(',,,');
 			io.emit('start', { artist: a[0], title: a[1], album: a[2], coverArt: a[3], rating: a[4] });
 	}
 

--- a/index.js
+++ b/index.js
@@ -4,9 +4,10 @@ var server = require('http').createServer(app);
 var io = require('socket.io')(server);
 var fs = require('fs');
 
-var fifo = 'ctl';
+var fifo = process.env.PIANOBAR_FIFO || 'ctl';
+var listenPort = process.env.PATIOBAR_PORT || 3000;
 
-server.listen(3000);
+server.listen(listenPort);
 
 // Routing
 app.use(express.static(__dirname + '/views'));


### PR DESCRIPTION
Two minor changes, that should be non-breaking:

* Add the option to configure the location of the fifo and the port number via environment variables while leaving the defaults the same. If you don't set the environment variables, nothing changes.
* Change the delimiter in the currentSong file to three commas instead of one. This is because *Crosby, Stills, Nash, and Young* and other artists/songs with commas exist :)